### PR TITLE
Implement Upload Sample page with a dummy API client

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,6 +28,8 @@ jobs:
           fetch-depth: 0
 
       - uses: hynek/build-and-inspect-python-package@v2
+        with:
+          skip-wheel: true
 
   publish:
     needs: [dist]

--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,7 @@ Thumbs.db
 # Common editor files
 *~
 *.swp
+
+
+# VSCode
+.vscode/*

--- a/src/genetic_forensic_portal/app/client/gf_api_client.py
+++ b/src/genetic_forensic_portal/app/client/gf_api_client.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+MISSING_DATA_ERROR = "data is required"
+
+
+def upload_sample_analysis(data: bytes, metadata: str | None = None) -> str:
+    # This is a placeholder. Eventually, the real API call will be here
+    # and we can return its response
+
+    if data is None:
+        raise ValueError(MISSING_DATA_ERROR)
+
+    sample_identifier = "this-is-a-uuid"
+
+    if metadata is None:
+        sample_identifier = "this-is-a-differentuuid"
+
+    return sample_identifier

--- a/src/genetic_forensic_portal/app/client/gf_api_client.py
+++ b/src/genetic_forensic_portal/app/client/gf_api_client.py
@@ -1,18 +1,25 @@
 from __future__ import annotations
 
 MISSING_DATA_ERROR = "data is required"
+SAMPLE_UUID = "this-is-a-uuid"
+NO_METADATA_UUID = "this-is-a-differentuuid"
 
 
 def upload_sample_analysis(data: bytes, metadata: str | None = None) -> str:
+    """Uploads a sample analysis from the web portal to the API
+
+    Args:
+        data (bytes): The data to upload
+        metadata (str | None): The metadata to upload"""
     # This is a placeholder. Eventually, the real API call will be here
     # and we can return its response
 
     if data is None:
         raise ValueError(MISSING_DATA_ERROR)
 
-    sample_identifier = "this-is-a-uuid"
+    sample_identifier = SAMPLE_UUID
 
     if metadata is None:
-        sample_identifier = "this-is-a-differentuuid"
+        sample_identifier = NO_METADATA_UUID
 
     return sample_identifier

--- a/src/genetic_forensic_portal/app/pages/2_Upload_Sample.py
+++ b/src/genetic_forensic_portal/app/pages/2_Upload_Sample.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import streamlit as st
+
+from genetic_forensic_portal.app.client import gf_api_client as client
+
+st.write("Upload Sample")
+with st.form(key="my_form"):
+    data = st.file_uploader(
+        "Upload Sample Data: ", type=["tsv"], accept_multiple_files=False
+    )
+    location = st.text_input("Location seized: ")
+    submit_button = st.form_submit_button(label="Submit")
+    if submit_button:
+        st.write("Sample uploaded successfully!")
+        st.write("metadata: ", location)
+        uuid = client.upload_sample_analysis(data=data, metadata=location)
+        st.write("Sample UUID: ", uuid)

--- a/tests/app/client/test_gf_api_client.py
+++ b/tests/app/client/test_gf_api_client.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import pytest
+
+import genetic_forensic_portal.app.client.gf_api_client as client
+
+TEST_FILE_DATA = b"this is a file"
+TEST_METADATA = "this is metadata"
+
+
+def test_upload_file_returns_uuid():
+    response = client.upload_sample_analysis(TEST_FILE_DATA, TEST_METADATA)
+
+    assert response == client.SAMPLE_UUID
+
+
+def test_upload_nothing_returns_error():
+    with pytest.raises(ValueError, match=client.MISSING_DATA_ERROR):
+        client.upload_sample_analysis(None)  # type: ignore[arg-type]
+
+
+def test_upload_no_metadata_returns_different_uuid():
+    response = client.upload_sample_analysis(TEST_FILE_DATA)
+
+    assert response == client.NO_METADATA_UUID


### PR DESCRIPTION
Adds a basic "Upload Sample" page which allows upload of a .tsv value and some optional text metadata and returns a "UUID" of said sample.

Also creates a dummy API client for the page to call, a placeholder for when there's a real API service that can be called