### PR TITLE
ci: Add .binder reference dir for docker build

### DIFF
--- a/.binder/apt.txt
+++ b/.binder/apt.txt
@@ -1,0 +1,1 @@
+../.devcontainer/apt.txt

--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -1,0 +1,1 @@
+../.devcontainer/postBuild

--- a/.binder/start
+++ b/.binder/start
@@ -1,0 +1,1 @@
+../.devcontainer/start

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,4 +3,4 @@
 # files (such as conda-linux-64.lock, start) in this repo.
 # Refer to the base-image/Dockerfile for documentation.
 ARG SSEC_BASE_IMAGE_TAG=latest
-FROM base-image:${SSEC_BASE_IMAGE_TAG}
+FROM ghcr.io/uw-ssec/base-image:${SSEC_BASE_IMAGE_TAG}

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,4 +3,4 @@
 # files (such as conda-linux-64.lock, start) in this repo.
 # Refer to the base-image/Dockerfile for documentation.
 ARG SSEC_BASE_IMAGE_TAG=latest
-FROM ghcr.io/uw-ssec/base-image:${SSEC_BASE_IMAGE_TAG}
+FROM base-image:${SSEC_BASE_IMAGE_TAG}

--- a/.devcontainer/postBuild
+++ b/.devcontainer/postBuild
@@ -1,0 +1,12 @@
+#/bin/bash -l
+
+# Install genetic portal package if pyproject.toml exists
+TARGET_FILE="${HOME}/pyproject.toml"
+
+if [ -f "$TARGET_FILE" ]
+then
+    echo "$TARGET_FILE exists. Installing package."
+    pip install "${HOME}"
+else
+    echo "$TARGET_FILE does not exist. Skipping install."
+fi

--- a/.devcontainer/start
+++ b/.devcontainer/start
@@ -3,7 +3,6 @@
 # ==== ONLY EDIT WITHIN THIS BLOCK =====
 
 
-
 # ==== ONLY EDIT WITHIN THIS BLOCK =====
 
 exec "$@"


### PR DESCRIPTION
This PR adds a `.binder` reference directory for the base image to get dependency from so that a docker image can be built by doing:

```console
docker build -t genetic-forensic-portal -f .devcontainer/Dockerfile .
```

once build you can run the portal by doing:

```console
docker run -it --rm -p 8501:8501 genetic-forensic-portal:latest gf-portal
```

## Demo

<img width="1495" alt="Screenshot 2024-05-14 at 2 57 46 PM" src="https://github.com/uw-ssec/genetic-forensic-portal/assets/17802172/60b77180-8be4-4406-a454-015e3f5a783c">

Closes #21 
