### PR TITLE
Add List Analyses page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12"]
         runs-on: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
         runs-on: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,6 @@ jobs:
       - uses: pre-commit/action@v3.0.1
         with:
           extra_args: --hook-stage manual --all-files
-      - name: Run PyLint
-        run: |
-          echo "::add-matcher::$GITHUB_WORKSPACE/.github/matchers/pylint.json"
-          pipx run nox -s pylint
 
   checks:
     name: Check Python ${{ matrix.python-version }} on ${{ matrix.runs-on }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 description = "A web frontend for the submission and analysis of anti-poaching genetic forensic data."
 readme = "README.md"
 license.file = "LICENSE"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 classifiers = [
   "Development Status :: 1 - Planning",
   "Intended Audience :: Science/Research",
@@ -21,9 +21,9 @@ classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Scientific/Engineering",
   "Typing :: Typed",
 ]
@@ -90,7 +90,7 @@ report.exclude_also = [
 
 [tool.mypy]
 files = ["src", "tests"]
-python_version = "3.10"
+python_version = "3.11"
 warn_unused_configs = true
 strict = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
@@ -143,7 +143,7 @@ ignore = [
 
 # May not need
 [tool.pylint]
-py-version = "3.8"
+py-version = "3.11"
 ignore-paths = [".*/_version.py"]
 reports.output-format = "colorized"
 similarities.ignore-imports = "yes"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
-  "Programming Language :: Python :: 3.13",
   "Topic :: Scientific/Engineering",
   "Typing :: Typed",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ report.exclude_also = [
 
 [tool.mypy]
 files = ["src", "tests"]
-python_version = "3.8"
+python_version = "3.10"
 warn_unused_configs = true
 strict = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]

--- a/src/genetic_forensic_portal/app/client/gf_api_client.py
+++ b/src/genetic_forensic_portal/app/client/gf_api_client.py
@@ -161,7 +161,7 @@ def list_analyses() -> list[str]:
     return UUID_LIST
 
 
-def get_analysis_status(sample_id: str) -> str:
+def get_analysis_status(sample_id: str) -> AnalysisStatus:
     """
     Retrieves the status of the analysis based on the given UUID.
 
@@ -176,11 +176,11 @@ def get_analysis_status(sample_id: str) -> str:
         raise ValueError(MISSING_UUID_ERROR)
 
     if sample_id in [SAMPLE_UUID, NO_METADATA_UUID]:
-        return AnalysisStatus.ANALYSIS_SUCCEEDED.value
+        return AnalysisStatus.ANALYSIS_SUCCEEDED
     if sample_id == IN_PROGRESS_UUID:
-        return AnalysisStatus.ANALYSIS_IN_PROGRESS.value
+        return AnalysisStatus.ANALYSIS_IN_PROGRESS
     if sample_id == ANALYSIS_FAILED_UUID:
-        return AnalysisStatus.ANALYSIS_FAILED.value
+        return AnalysisStatus.ANALYSIS_FAILED
 
     error_message = "No analysis found for the given UUID"
     raise FileNotFoundError(error_message)

--- a/src/genetic_forensic_portal/app/client/gf_api_client.py
+++ b/src/genetic_forensic_portal/app/client/gf_api_client.py
@@ -155,24 +155,28 @@ def get_familial_analysis(sample_id: str) -> pd.DataFrame:
         raise RuntimeError(FAMILIAL_TSV_ERROR) from None
 
 
-def list_analyses(next_token: int | None = None) -> ListAnalysesResponse:
+def list_analyses(next_token: int = 0) -> ListAnalysesResponse:
     """Lists UUIDs for all SCAT analyses
 
     Returns:
-        list[str]: A list of all SCAT analyses"""
+        ListAnalysesResponse: A list of all SCAT analyses with indications of pagination"""
     # This is a placeholder. Eventually, the real API call will be here
     # and we can return its response
-    if next_token is None or next_token <= 0:
-        # return first page
-        return ListAnalysesResponse(
-            UUID_LIST[:DEFAULT_LIST_PAGE_SIZE], next_token=DEFAULT_LIST_PAGE_SIZE
-        )
 
-    if next_token < len(UUID_LIST):
-        # print(f"Next token: {next_token}")
-        return ListAnalysesResponse(UUID_LIST[next_token:], start_token=next_token)
+    # check for out of bounds
+    if next_token >= len(UUID_LIST):
+        return ListAnalysesResponse([])
 
-    return ListAnalysesResponse([])
+    # set reasonable bounds for the page
+    new_start_token = max(next_token, 0)
+    new_end_token = min(next_token + DEFAULT_LIST_PAGE_SIZE, len(UUID_LIST))
+    new_next_token = new_end_token if new_end_token < len(UUID_LIST) else None
+
+    return ListAnalysesResponse(
+        UUID_LIST[new_start_token:new_end_token],
+        start_token=new_start_token,
+        next_token=new_next_token,
+    )
 
 
 def list_all_analyses() -> list[str]:

--- a/src/genetic_forensic_portal/app/client/models/list_analyses_response.py
+++ b/src/genetic_forensic_portal/app/client/models/list_analyses_response.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+
+class ListAnalysesResponse:
+    def __init__(
+        self, analyses: list[str], start_token: int = 0, next_token: int | None = None
+    ):
+        self.analyses = analyses
+        self.start_token = start_token
+        self.next_token = next_token

--- a/src/genetic_forensic_portal/app/pages/3_Get_Analysis_Status.py
+++ b/src/genetic_forensic_portal/app/pages/3_Get_Analysis_Status.py
@@ -8,7 +8,7 @@ st.title("Get Analysis Status")
 
 uuid = st.selectbox(
     "Select a sample ID",
-    client.list_analyses(),
+    client.list_all_analyses(),
     index=None,
     placeholder="Select sample ID...",
 )

--- a/src/genetic_forensic_portal/app/pages/3_Get_Analysis_Status.py
+++ b/src/genetic_forensic_portal/app/pages/3_Get_Analysis_Status.py
@@ -15,7 +15,7 @@ uuid = st.selectbox(
 
 if uuid:
     try:
-        status = client.get_analysis_status(uuid)
+        status = client.get_analysis_status(uuid).value
         st.success(f"Current status of the analysis: {status}")
     except ValueError as ve:
         st.error(f"Invalid input: {ve}")

--- a/src/genetic_forensic_portal/app/pages/4_Get_SCAT_Analysis.py
+++ b/src/genetic_forensic_portal/app/pages/4_Get_SCAT_Analysis.py
@@ -13,7 +13,7 @@ analysis_list = client.list_all_analyses()
 uuid = st.selectbox(
     "Select a sample ID",
     analysis_list,
-    index=st.session_state.index if "index" in st.session_state else None,
+    index=getattr(st.session_state, "index", None),
     placeholder="Select sample ID...",
 )
 

--- a/src/genetic_forensic_portal/app/pages/4_Get_SCAT_Analysis.py
+++ b/src/genetic_forensic_portal/app/pages/4_Get_SCAT_Analysis.py
@@ -6,7 +6,7 @@ from genetic_forensic_portal.app.client import gf_api_client as client
 
 st.header("Get SCAT Analysis")
 
-uuid = st.session_state.uuid if "uuid" in st.session_state else None
+uuid = getattr(st.session_state, "uuid", None)
 
 analysis_list = client.list_all_analyses()
 

--- a/src/genetic_forensic_portal/app/pages/4_Get_SCAT_Analysis.py
+++ b/src/genetic_forensic_portal/app/pages/4_Get_SCAT_Analysis.py
@@ -8,7 +8,7 @@ st.header("Get SCAT Analysis")
 
 uuid = st.session_state.uuid if "uuid" in st.session_state else None
 
-analysis_list = client.list_analyses()
+analysis_list = client.list_all_analyses()
 
 uuid = st.selectbox(
     "Select a sample ID",

--- a/src/genetic_forensic_portal/app/pages/4_Get_SCAT_Analysis.py
+++ b/src/genetic_forensic_portal/app/pages/4_Get_SCAT_Analysis.py
@@ -6,10 +6,14 @@ from genetic_forensic_portal.app.client import gf_api_client as client
 
 st.header("Get SCAT Analysis")
 
+uuid = st.session_state.uuid if "uuid" in st.session_state else None
+
+analysis_list = client.list_analyses()
+
 uuid = st.selectbox(
     "Select a sample ID",
-    client.list_analyses(),
-    index=None,
+    analysis_list,
+    index=st.session_state.index if "index" in st.session_state else None,
     placeholder="Select sample ID...",
 )
 

--- a/src/genetic_forensic_portal/app/pages/5_Get_Voronoi_Analysis.py
+++ b/src/genetic_forensic_portal/app/pages/5_Get_Voronoi_Analysis.py
@@ -6,7 +6,7 @@ from genetic_forensic_portal.app.client import gf_api_client as client
 
 st.header("Get Voronoi Analysis")
 
-uuid = st.session_state.uuid if "uuid" in st.session_state else None
+uuid = getattr(st.session_state, "uuid", None)
 
 analysis_list = client.list_all_analyses()
 

--- a/src/genetic_forensic_portal/app/pages/5_Get_Voronoi_Analysis.py
+++ b/src/genetic_forensic_portal/app/pages/5_Get_Voronoi_Analysis.py
@@ -13,7 +13,7 @@ analysis_list = client.list_all_analyses()
 uuid = st.selectbox(
     "Select a sample ID",
     client.list_analyses(),
-    index=st.session_state.index if "index" in st.session_state else None,
+    index=getattr(st.session_state, "index", None),
     placeholder="Select sample ID...",
 )
 

--- a/src/genetic_forensic_portal/app/pages/5_Get_Voronoi_Analysis.py
+++ b/src/genetic_forensic_portal/app/pages/5_Get_Voronoi_Analysis.py
@@ -6,10 +6,14 @@ from genetic_forensic_portal.app.client import gf_api_client as client
 
 st.header("Get Voronoi Analysis")
 
+uuid = st.session_state.uuid if "uuid" in st.session_state else None
+
+analysis_list = client.list_analyses()
+
 uuid = st.selectbox(
     "Select a sample ID",
     client.list_analyses(),
-    index=None,
+    index=st.session_state.index if "index" in st.session_state else None,
     placeholder="Select sample ID...",
 )
 

--- a/src/genetic_forensic_portal/app/pages/5_Get_Voronoi_Analysis.py
+++ b/src/genetic_forensic_portal/app/pages/5_Get_Voronoi_Analysis.py
@@ -12,7 +12,7 @@ analysis_list = client.list_all_analyses()
 
 uuid = st.selectbox(
     "Select a sample ID",
-    client.list_analyses(),
+    client.list_all_analyses(),
     index=getattr(st.session_state, "index", None),
     placeholder="Select sample ID...",
 )

--- a/src/genetic_forensic_portal/app/pages/5_Get_Voronoi_Analysis.py
+++ b/src/genetic_forensic_portal/app/pages/5_Get_Voronoi_Analysis.py
@@ -8,7 +8,7 @@ st.header("Get Voronoi Analysis")
 
 uuid = st.session_state.uuid if "uuid" in st.session_state else None
 
-analysis_list = client.list_analyses()
+analysis_list = client.list_all_analyses()
 
 uuid = st.selectbox(
     "Select a sample ID",

--- a/src/genetic_forensic_portal/app/pages/6_Get_Familial_Analysis.py
+++ b/src/genetic_forensic_portal/app/pages/6_Get_Familial_Analysis.py
@@ -14,7 +14,7 @@ analysis_list = client.list_all_analyses()
 uuid = st.selectbox(
     "Select a sample ID",
     analysis_list,
-    index=st.session_state.index if "index" in st.session_state else None,
+    index=getattr(st.session_state, "index", None),
     placeholder="Select sample ID...",
 )
 

--- a/src/genetic_forensic_portal/app/pages/6_Get_Familial_Analysis.py
+++ b/src/genetic_forensic_portal/app/pages/6_Get_Familial_Analysis.py
@@ -9,7 +9,7 @@ st.header("Get Familial Analysis")
 
 uuid = st.session_state.uuid if "uuid" in st.session_state else None
 
-analysis_list = client.list_analyses()
+analysis_list = client.list_all_analyses()
 
 uuid = st.selectbox(
     "Select a sample ID",

--- a/src/genetic_forensic_portal/app/pages/6_Get_Familial_Analysis.py
+++ b/src/genetic_forensic_portal/app/pages/6_Get_Familial_Analysis.py
@@ -7,10 +7,14 @@ from genetic_forensic_portal.app.client import gf_api_client as client
 
 st.header("Get Familial Analysis")
 
+uuid = st.session_state.uuid if "uuid" in st.session_state else None
+
+analysis_list = client.list_analyses()
+
 uuid = st.selectbox(
     "Select a sample ID",
-    client.list_analyses(),
-    index=None,
+    analysis_list,
+    index=st.session_state.index if "index" in st.session_state else None,
     placeholder="Select sample ID...",
 )
 

--- a/src/genetic_forensic_portal/app/pages/6_Get_Familial_Analysis.py
+++ b/src/genetic_forensic_portal/app/pages/6_Get_Familial_Analysis.py
@@ -7,7 +7,7 @@ from genetic_forensic_portal.app.client import gf_api_client as client
 
 st.header("Get Familial Analysis")
 
-uuid = st.session_state.uuid if "uuid" in st.session_state else None
+uuid = getattr(st.session_state, "uuid", None)
 
 analysis_list = client.list_all_analyses()
 

--- a/src/genetic_forensic_portal/app/pages/8_List_Analyses.py
+++ b/src/genetic_forensic_portal/app/pages/8_List_Analyses.py
@@ -25,11 +25,6 @@ st.header("List Analyses")
 analyses = client.list_analyses()
 statuses = [try_get_analysis(analysis) for analysis in analyses]
 
-results = zip(range(len(analyses)), analyses, statuses, strict=False)
-results = sorted(results, key=lambda x: x[2])
-
-statuses = [try_get_analysis(analysis) for analysis in analyses]
-
 results = zip(range(len(analyses)), analyses, statuses, strict=True)
 sorted_results = sorted(results, key=lambda x: x[2])
 

--- a/src/genetic_forensic_portal/app/pages/8_List_Analyses.py
+++ b/src/genetic_forensic_portal/app/pages/8_List_Analyses.py
@@ -15,15 +15,9 @@ def try_get_analysis(uuid: str) -> AnalysisStatus:
         return AnalysisStatus.ANALYSIS_ERROR
 
 
-st.session_state.sorted_results = (
-    [] if "sorted_results" not in st.session_state else st.session_state.sorted_results
-)
-st.session_state.analysis_start = (
-    0 if "analysis_start" not in st.session_state else st.session_state.analysis_start
-)
-st.session_state.analysis_next = (
-    None if "analysis_next" not in st.session_state else st.session_state.analysis_next
-)
+st.session_state.sorted_results = getattr(st.session_state, "sorted_results", [])
+st.session_state.analysis_start = getattr(st.session_state, "analysis_start", 0)
+st.session_state.analysis_next = getattr(st.session_state, "analysis_next", None)
 
 
 def update_session_state(uuid: str, index: int) -> None:
@@ -76,7 +70,7 @@ scat_col.write("**SCAT Analysis**")
 vor_col.write("**Voronoi Analysis**")
 fam_col.write("**Familial Analysis**")
 
-# TODO pagination
+
 for index, analysis, status in st.session_state.sorted_results:
     ana_col, status_col, scat_col, vor_col, fam_col = st.columns(
         [1, 0.7, 0.5, 0.5, 0.5]

--- a/src/genetic_forensic_portal/app/pages/8_List_Analyses.py
+++ b/src/genetic_forensic_portal/app/pages/8_List_Analyses.py
@@ -25,7 +25,7 @@ def update_session_state(uuid: str, index: int) -> None:
     st.session_state.index = index
 
 
-def retrieve_analyses(start: int | None = None) -> list[str]:
+def retrieve_analyses(start: int = 0) -> list[str]:
     if (
         len(st.session_state.sorted_results) == 0
         or st.session_state.analysis_next is not None

--- a/src/genetic_forensic_portal/app/pages/8_List_Analyses.py
+++ b/src/genetic_forensic_portal/app/pages/8_List_Analyses.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import streamlit as st
+
+from genetic_forensic_portal.app.client import gf_api_client as client
+
+
+def try_get_analysis(uuid: str) -> str:
+    try:
+        return client.get_analysis_status(uuid)
+    except FileNotFoundError:
+        return "NOT FOUND"
+    except Exception:
+        return "ERROR"
+
+
+def update_session_state(uuid: str, index: int) -> None:
+    st.session_state.uuid = uuid
+    st.session_state.index = index
+
+
+st.header("List Analyses")
+
+analyses = client.list_analyses()
+
+# TODO see if i can reorder rows so completed analyses are at the top
+# TODO color highlight based on status
+# TODO title columns
+# TODO pagination????
+for index, analysis in enumerate(analyses):
+    ana_col, status_col, scat_col, vor_col, fam_col = st.columns([1, 1, 0.5, 0.5, 0.5])
+    ana_col.write(analysis)
+    status_col.write(try_get_analysis(analysis))
+    with scat_col:
+        if st.button(key=f"SCAT {analysis}", label="SCAT"):
+            update_session_state(analysis, index)
+            st.switch_page("pages/4_Get_SCAT_Analysis.py")
+    with vor_col:
+        if st.button(key=f"Voronoi {analysis}", label="Voronoi"):
+            update_session_state(analysis, index)
+            st.switch_page("pages/5_Get_Voronoi_Analysis.py")
+    with fam_col:
+        if st.button(key=f"Familial {analysis}", label="Familial"):
+            update_session_state(analysis, index)
+            st.switch_page("pages/6_Get_Familial_Analysis.py")

--- a/src/genetic_forensic_portal/app/pages/8_List_Analyses.py
+++ b/src/genetic_forensic_portal/app/pages/8_List_Analyses.py
@@ -3,15 +3,16 @@ from __future__ import annotations
 import streamlit as st
 
 from genetic_forensic_portal.app.client import gf_api_client as client
+from genetic_forensic_portal.utils.analysis_status import AnalysisStatus
 
 
-def try_get_analysis(uuid: str) -> str:
+def try_get_analysis(uuid: str) -> AnalysisStatus:
     try:
         return client.get_analysis_status(uuid)
     except FileNotFoundError:
-        return "NOT FOUND"
+        return AnalysisStatus.ANALYSIS_NOT_FOUND
     except Exception:
-        return "ERROR"
+        return AnalysisStatus.ANALYSIS_ERROR
 
 
 def update_session_state(uuid: str, index: int) -> None:
@@ -22,24 +23,42 @@ def update_session_state(uuid: str, index: int) -> None:
 st.header("List Analyses")
 
 analyses = client.list_analyses()
+statuses = [try_get_analysis(analysis) for analysis in analyses]
 
-# TODO see if i can reorder rows so completed analyses are at the top
-# TODO color highlight based on status
-# TODO title columns
-# TODO pagination????
-for index, analysis in enumerate(analyses):
-    ana_col, status_col, scat_col, vor_col, fam_col = st.columns([1, 1, 0.5, 0.5, 0.5])
+results = zip(range(len(analyses)), analyses, statuses)
+results = sorted(results, key=lambda x: x[2])
+
+statuses = [try_get_analysis(analysis) for analysis in analyses]
+
+results = zip(range(len(analyses)), analyses, statuses, strict=True)
+sorted_results = sorted(results, key=lambda x: x[2])
+
+ana_col, status_col, scat_col, vor_col, fam_col = st.columns([1, 0.7, 0.5, 0.5, 0.5])
+ana_col.write("**Analysis ID**")
+status_col.write("**Status**")
+scat_col.write("**SCAT Analysis**")
+vor_col.write("**Voronoi Analysis**")
+fam_col.write("**Familial Analysis**")
+
+for index, analysis, status in sorted_results:
+    ana_col, status_col, scat_col, vor_col, fam_col = st.columns(
+        [1, 0.7, 0.5, 0.5, 0.5]
+    )
     ana_col.write(analysis)
-    status_col.write(try_get_analysis(analysis))
+    status_col.write(status.value)
     with scat_col:
-        if st.button(key=f"SCAT {analysis}", label="SCAT"):
+        if st.button(key=f"SCAT {analysis}", label="SCAT", use_container_width=True):
             update_session_state(analysis, index)
             st.switch_page("pages/4_Get_SCAT_Analysis.py")
     with vor_col:
-        if st.button(key=f"Voronoi {analysis}", label="Voronoi"):
+        if st.button(
+            key=f"Voronoi {analysis}", label="Voronoi", use_container_width=True
+        ):
             update_session_state(analysis, index)
             st.switch_page("pages/5_Get_Voronoi_Analysis.py")
     with fam_col:
-        if st.button(key=f"Familial {analysis}", label="Familial"):
+        if st.button(
+            key=f"Familial {analysis}", label="Familial", use_container_width=True
+        ):
             update_session_state(analysis, index)
             st.switch_page("pages/6_Get_Familial_Analysis.py")

--- a/src/genetic_forensic_portal/app/pages/8_List_Analyses.py
+++ b/src/genetic_forensic_portal/app/pages/8_List_Analyses.py
@@ -25,7 +25,7 @@ st.header("List Analyses")
 analyses = client.list_analyses()
 statuses = [try_get_analysis(analysis) for analysis in analyses]
 
-results = zip(range(len(analyses)), analyses, statuses)
+results = zip(range(len(analyses)), analyses, statuses, strict=False)
 results = sorted(results, key=lambda x: x[2])
 
 statuses = [try_get_analysis(analysis) for analysis in analyses]

--- a/src/genetic_forensic_portal/app/pages/8_List_Analyses.py
+++ b/src/genetic_forensic_portal/app/pages/8_List_Analyses.py
@@ -37,10 +37,12 @@ def retrieve_analyses(start: int | None = None) -> list[str]:
     return []
 
 
-def retrieve_and_sort_analyses(start: int | None = None) -> None:
+def retrieve_and_sort_analyses(start: int = 0) -> None:
     analyses = retrieve_analyses(start)
     statuses = [try_get_analysis(analysis) for analysis in analyses]
-    results = list(zip(range(len(analyses)), analyses, statuses, strict=True))
+    results = list(
+        zip(range(start, start + len(analyses)), analyses, statuses, strict=True)
+    )
     full_results = st.session_state.sorted_results + results
     st.session_state.sorted_results = sorted(full_results, key=lambda x: x[2])
 

--- a/src/genetic_forensic_portal/utils/analysis_status.py
+++ b/src/genetic_forensic_portal/utils/analysis_status.py
@@ -1,23 +1,27 @@
 # src/genetic_forensic_portal/util/status_enum.py
 from __future__ import annotations
 
-from enum import Enum
+from enum import StrEnum
 
 
-class AnalysisStatus(Enum):
+class AnalysisStatus(StrEnum):
     ANALYSIS_SUCCEEDED = "Analysis succeeded"
     ANALYSIS_IN_PROGRESS = "Analysis in progress"
     ANALYSIS_FAILED = "Analysis failed"
     ANALYSIS_NOT_FOUND = "NOT FOUND"
     ANALYSIS_ERROR = "ERROR"
 
-    def _get_ordering(self: AnalysisStatus) -> dict[AnalysisStatus, int]:
+    def _get_ordering(self: AnalysisStatus) -> dict[str, int]:
         return {name: idx for idx, name in enumerate(self.__class__)}
 
-    def __lt__(self: AnalysisStatus, other: AnalysisStatus) -> bool:
+    def __lt__(self: AnalysisStatus, other: str) -> bool:
         ordering = self._get_ordering()
+        if other not in ordering:
+            return super().__lt__(other)
         return ordering[self] < ordering[other]
 
-    def __gt__(self: AnalysisStatus, other: AnalysisStatus) -> bool:
+    def __gt__(self: AnalysisStatus, other: str) -> bool:
         ordering = self._get_ordering()
+        if other not in ordering:
+            return super().__gt__(other)
         return ordering[self] > ordering[other]

--- a/src/genetic_forensic_portal/utils/analysis_status.py
+++ b/src/genetic_forensic_portal/utils/analysis_status.py
@@ -1,4 +1,6 @@
 # src/genetic_forensic_portal/util/status_enum.py
+from __future__ import annotations
+
 from enum import Enum
 
 
@@ -6,3 +8,16 @@ class AnalysisStatus(Enum):
     ANALYSIS_SUCCEEDED = "Analysis succeeded"
     ANALYSIS_IN_PROGRESS = "Analysis in progress"
     ANALYSIS_FAILED = "Analysis failed"
+    ANALYSIS_NOT_FOUND = "NOT FOUND"
+    ANALYSIS_ERROR = "ERROR"
+
+    def _get_ordering(self: AnalysisStatus) -> dict[AnalysisStatus, int]:
+        return {name: idx for idx, name in enumerate(self.__class__)}
+
+    def __lt__(self: AnalysisStatus, other: AnalysisStatus) -> bool:
+        ordering = self._get_ordering()
+        return ordering[self] < ordering[other]
+
+    def __gt__(self: AnalysisStatus, other: AnalysisStatus) -> bool:
+        ordering = self._get_ordering()
+        return ordering[self] > ordering[other]

--- a/tests/app/client/test_gf_api_client.py
+++ b/tests/app/client/test_gf_api_client.py
@@ -92,17 +92,17 @@ def test_get_voronoi_analysis_raises_error_for_none():
 # Tests for the get_analysis_status function
 def test_get_analysis_status_succeeded():
     response = client.get_analysis_status(client.SAMPLE_UUID)
-    assert response == AnalysisStatus.ANALYSIS_SUCCEEDED.value
+    assert response == AnalysisStatus.ANALYSIS_SUCCEEDED
 
 
 def test_get_analysis_status_in_progress():
     response = client.get_analysis_status(client.IN_PROGRESS_UUID)
-    assert response == AnalysisStatus.ANALYSIS_IN_PROGRESS.value
+    assert response == AnalysisStatus.ANALYSIS_IN_PROGRESS
 
 
 def test_get_analysis_status_failed():
     response = client.get_analysis_status(client.ANALYSIS_FAILED_UUID)
-    assert response == AnalysisStatus.ANALYSIS_FAILED.value
+    assert response == AnalysisStatus.ANALYSIS_FAILED
 
 
 def test_get_analysis_status_not_found():

--- a/tests/app/client/test_gf_api_client.py
+++ b/tests/app/client/test_gf_api_client.py
@@ -80,6 +80,26 @@ def test_list_analyses_with_start_returns_correct_page():
     assert response.next_token is None
 
 
+def test_list_analyses_with_early_returns_page_with_correct_size():
+    start_token = 1
+    response = client.list_analyses(start_token)
+
+    expected_end = start_token + client.DEFAULT_LIST_PAGE_SIZE
+
+    assert response.analyses == client.UUID_LIST[start_token:expected_end]
+    assert len(response.analyses) == client.DEFAULT_LIST_PAGE_SIZE
+    assert response.start_token == start_token
+    assert response.next_token == expected_end
+
+
+def test_list_analyses_with_out_of_bounds_start_returns_empty_list():
+    response = client.list_analyses(100)
+
+    assert response.analyses == []
+    assert response.start_token == 0
+    assert response.next_token is None
+
+
 # Voronoi Analysis
 
 

--- a/tests/app/client/test_gf_api_client.py
+++ b/tests/app/client/test_gf_api_client.py
@@ -58,10 +58,26 @@ def test_get_scat_analysis_raises_error_for_none():
         client.get_scat_analysis(None)  # type: ignore[arg-type]
 
 
-def test_list_analyses_returns_list():
-    response = client.list_analyses()
+def test_list_all_analyses_returns_list():
+    response = client.list_all_analyses()
 
     assert response == client.UUID_LIST
+
+
+def test_list_analyses_returns_response_object():
+    response = client.list_analyses()
+
+    assert response.analyses == client.UUID_LIST[: client.DEFAULT_LIST_PAGE_SIZE]
+    assert response.start_token == 0
+    assert response.next_token == client.DEFAULT_LIST_PAGE_SIZE
+
+
+def test_list_analyses_with_start_returns_correct_page():
+    response = client.list_analyses(client.DEFAULT_LIST_PAGE_SIZE)
+
+    assert response.analyses == client.UUID_LIST[client.DEFAULT_LIST_PAGE_SIZE :]
+    assert response.start_token == client.DEFAULT_LIST_PAGE_SIZE
+    assert response.next_token is None
 
 
 # Voronoi Analysis

--- a/tests/utils/test_analysis_status.py
+++ b/tests/utils/test_analysis_status.py
@@ -1,0 +1,19 @@
+from genetic_forensic_portal.utils.analysis_status import AnalysisStatus
+
+
+def test_ordering():
+    """Test the ordering of the AnalysisStatus enum.
+    Order should be
+    ANALYSIS_SUCCEEDED < ANALYSIS_IN_PROGRESS < ANALYSIS_FAILED < ANALYSIS_NOT_FOUND < ANALYSIS_ERROR
+    """
+    # less than
+    assert AnalysisStatus.ANALYSIS_SUCCEEDED < AnalysisStatus.ANALYSIS_IN_PROGRESS
+    assert AnalysisStatus.ANALYSIS_IN_PROGRESS < AnalysisStatus.ANALYSIS_FAILED
+    assert AnalysisStatus.ANALYSIS_FAILED < AnalysisStatus.ANALYSIS_NOT_FOUND
+    assert AnalysisStatus.ANALYSIS_NOT_FOUND < AnalysisStatus.ANALYSIS_ERROR
+
+    # greater than
+    assert AnalysisStatus.ANALYSIS_ERROR > AnalysisStatus.ANALYSIS_NOT_FOUND
+    assert AnalysisStatus.ANALYSIS_NOT_FOUND > AnalysisStatus.ANALYSIS_FAILED
+    assert AnalysisStatus.ANALYSIS_FAILED > AnalysisStatus.ANALYSIS_IN_PROGRESS
+    assert AnalysisStatus.ANALYSIS_IN_PROGRESS > AnalysisStatus.ANALYSIS_SUCCEEDED

--- a/tests/utils/test_analysis_status.py
+++ b/tests/utils/test_analysis_status.py
@@ -17,3 +17,8 @@ def test_ordering():
     assert AnalysisStatus.ANALYSIS_NOT_FOUND > AnalysisStatus.ANALYSIS_FAILED
     assert AnalysisStatus.ANALYSIS_FAILED > AnalysisStatus.ANALYSIS_IN_PROGRESS
     assert AnalysisStatus.ANALYSIS_IN_PROGRESS > AnalysisStatus.ANALYSIS_SUCCEEDED
+
+
+def test_ordering_with_arbitrary_strings_uses_string_ordering():
+    assert AnalysisStatus.ANALYSIS_SUCCEEDED < "ZZZZZZZ"
+    assert AnalysisStatus.ANALYSIS_SUCCEEDED > "AAAAAAA"


### PR DESCRIPTION
Adds a List Analyses page displaying links to the various SCAT, Voronoi, and Familial analyses for a given analysis ID.

Sorts the list "API call" output so completed analyses are first on the list.

Remaining work for this page (if I can manage to wrangle it):
* ~pagination support~ DONE with new commit
* color rows (or at least text) based on analysis status
* adding links to the global analysis page from #16 once that code's merged and out there